### PR TITLE
Add an extension that allows intersphinx to be disabled on the command-line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,20 @@ jobs:
             conda config --set always_yes yes --set changeps1 no
             conda update -n root conda
       - run:
+          name: Run tests with Sphinx 1.8
+          command: |
+            conda create -q -n sphinx18 sphinx=1.8 pytest
+            source activate sphinx18
+            pip install .
+            pytest sphinx_astropy
+      - run:
+          name: Run tests with Sphinx 1.7
+          command: |
+            conda create -q -n sphinx17 sphinx=1.7 pytest
+            source activate sphinx17
+            pip install .
+            pytest sphinx_astropy
+      - run:
           name: Run tests with Sphinx 1.6
           command: |
             conda create -q -n sphinx16 sphinx=1.6 pytest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changes in sphinx-astropy
 
 - Added a new extension for controlling whether intersphinx is used on the command-line.
 
+- Added a new extension to give a clear warning if the _static folder is missing.
+
 1.0 (2018-02-07)
 ----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes in sphinx-astropy
 1.1 (unreleased)
 ----------------
 
-- No changes yet.
+- Added a new extension for controlling whether intersphinx is used on the command-line.
 
 1.0 (2018-02-07)
 ----------------

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -136,7 +136,8 @@ extensions = [
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.smart_resolver',
     'sphinx_astropy.ext.doctest',
-    'sphinx_astropy.ext.changelog_links']
+    'sphinx_astropy.ext.changelog_links',
+    'sphinx_astropy.ext.intersphinx_toggle']
 
 
 if not on_rtd and LooseVersion(sphinx.__version__) < LooseVersion('1.4'):

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -137,8 +137,8 @@ extensions = [
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.smart_resolver',
     'sphinx_astropy.ext.doctest',
-    'sphinx_astropy.ext.changelog_links']
-
+    'sphinx_astropy.ext.changelog_links',
+    'sphinx_astropy.ext.missing_static']
 
 if not on_rtd and LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
     extensions.append('sphinx.ext.pngmath')

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -126,6 +126,7 @@ suppress_warnings = ['app.add_directive', ]
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_astropy.ext.intersphinx_toggle',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
@@ -136,8 +137,7 @@ extensions = [
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.smart_resolver',
     'sphinx_astropy.ext.doctest',
-    'sphinx_astropy.ext.changelog_links',
-    'sphinx_astropy.ext.intersphinx_toggle']
+    'sphinx_astropy.ext.changelog_links']
 
 
 if not on_rtd and LooseVersion(sphinx.__version__) < LooseVersion('1.4'):

--- a/sphinx_astropy/ext/intersphinx_toggle.py
+++ b/sphinx_astropy/ext/intersphinx_toggle.py
@@ -1,0 +1,28 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+The purpose of this extension is to provide a configuration value that can be
+used to disable intersphinx on the command-line without editing conf.py. To use,
+you can build documentation with::
+
+    sphinx-build ... -D disable_intersphinx=1
+
+This is used e.g. by astropy-helpers when using the build_docs command.
+"""
+
+from __future__ import print_function
+from sphinx.util import logging
+from sphinx.util.console import bold
+
+logger = logging.getLogger(__name__)
+
+
+def disable_intersphinx(app, config):
+    if config.disable_intersphinx:
+        logger.info(bold('disabling intersphinx...'))
+        config.intersphinx_mapping.clear()
+
+
+def setup(app):
+    app.connect('config-inited', disable_intersphinx)
+    app.add_config_value('disable_intersphinx', 0, True)

--- a/sphinx_astropy/ext/intersphinx_toggle.py
+++ b/sphinx_astropy/ext/intersphinx_toggle.py
@@ -11,8 +11,14 @@ This is used e.g. by astropy-helpers when using the build_docs command.
 """
 
 from __future__ import print_function
+
+from distutils.version import LooseVersion
+
+from sphinx import __version__
 from sphinx.util import logging
 from sphinx.util.console import bold
+
+SPHINX_GE_18 = LooseVersion(__version__) >= LooseVersion('1.8')
 
 logger = logging.getLogger(__name__)
 
@@ -24,5 +30,7 @@ def disable_intersphinx(app, config):
 
 
 def setup(app):
-    app.connect('config-inited', disable_intersphinx)
-    app.add_config_value('disable_intersphinx', 0, True)
+    # Note that the config-inited setting was only added in Sphinx 1.8
+    if SPHINX_GE_18:
+        app.connect('config-inited', disable_intersphinx)
+        app.add_config_value('disable_intersphinx', 0, True)

--- a/sphinx_astropy/ext/intersphinx_toggle.py
+++ b/sphinx_astropy/ext/intersphinx_toggle.py
@@ -19,13 +19,13 @@ from sphinx import __version__
 SPHINX_LT_18 = LooseVersion(__version__) < LooseVersion('1.8')
 
 
-def disable_intersphinx(app, config):
+def disable_intersphinx(app, config=None):
     from sphinx.util import logging
     from sphinx.util.console import bold
     logger = logging.getLogger(__name__)
-    if config.disable_intersphinx:
+    if app.config.disable_intersphinx:
         logger.info(bold('disabling intersphinx...'))
-        config.intersphinx_mapping.clear()
+        app.config.intersphinx_mapping.clear()
 
 
 def setup(app):

--- a/sphinx_astropy/ext/intersphinx_toggle.py
+++ b/sphinx_astropy/ext/intersphinx_toggle.py
@@ -15,15 +15,14 @@ from __future__ import print_function
 from distutils.version import LooseVersion
 
 from sphinx import __version__
-from sphinx.util import logging
-from sphinx.util.console import bold
 
 SPHINX_GE_18 = LooseVersion(__version__) >= LooseVersion('1.8')
 
-logger = logging.getLogger(__name__)
-
 
 def disable_intersphinx(app, config):
+    from sphinx.util import logging
+    from sphinx.util.console import bold
+    logger = logging.getLogger(__name__)
     if config.disable_intersphinx:
         logger.info(bold('disabling intersphinx...'))
         config.intersphinx_mapping.clear()

--- a/sphinx_astropy/ext/intersphinx_toggle.py
+++ b/sphinx_astropy/ext/intersphinx_toggle.py
@@ -16,15 +16,22 @@ from distutils.version import LooseVersion
 
 from sphinx import __version__
 
+SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
 SPHINX_LT_18 = LooseVersion(__version__) < LooseVersion('1.8')
 
 
 def disable_intersphinx(app, config=None):
-    from sphinx.util import logging
+
     from sphinx.util.console import bold
-    logger = logging.getLogger(__name__)
+
+    if SPHINX_LT_16:
+        info = app.info
+    else:
+        from sphinx.util import logging
+        info = logging.getLogger(__name__).info
+
     if app.config.disable_intersphinx:
-        logger.info(bold('disabling intersphinx...'))
+        info(bold('disabling intersphinx...'))
         app.config.intersphinx_mapping.clear()
 
 

--- a/sphinx_astropy/ext/intersphinx_toggle.py
+++ b/sphinx_astropy/ext/intersphinx_toggle.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion
 
 from sphinx import __version__
 
-SPHINX_GE_18 = LooseVersion(__version__) >= LooseVersion('1.8')
+SPHINX_LT_18 = LooseVersion(__version__) < LooseVersion('1.8')
 
 
 def disable_intersphinx(app, config):
@@ -29,7 +29,13 @@ def disable_intersphinx(app, config):
 
 
 def setup(app):
-    # Note that the config-inited setting was only added in Sphinx 1.8
-    if SPHINX_GE_18:
+
+    # Note that the config-inited setting was only added in Sphinx 1.8. For
+    # earlier versions we use builder-inited but we need to be careful in what
+    # order the extensions are declared so that this happens before intersphinx.
+    if SPHINX_LT_18:
+        app.connect('builder-inited', disable_intersphinx)
+    else:
         app.connect('config-inited', disable_intersphinx)
-        app.add_config_value('disable_intersphinx', 0, True)
+
+    app.add_config_value('disable_intersphinx', 0, True)

--- a/sphinx_astropy/ext/missing_static.py
+++ b/sphinx_astropy/ext/missing_static.py
@@ -17,7 +17,8 @@ SPHINX_LT_18 = LooseVersion(__version__) < LooseVersion('1.8')
 
 
 WARNING_TEMPLATE = """
-Note: The static directory '{0}' was not found. If you don't need it then make
+Note: The static directory '{0}' was not found. This is often because it is
+      empty and you are using git. If so, you don't need it, so make
       sure it isn't included in the html_static_path setting in your conf.py
       file, otherwise Sphinx may fail the build if you are turning warnings into
       errors.

--- a/sphinx_astropy/ext/missing_static.py
+++ b/sphinx_astropy/ext/missing_static.py
@@ -1,0 +1,41 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+The purpose of this extension is to give a clear warning if sphinx is expecting
+a static directory to be present but it isn't.
+"""
+
+from __future__ import print_function
+
+import os
+from distutils.version import LooseVersion
+
+from sphinx import __version__
+
+SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
+SPHINX_LT_18 = LooseVersion(__version__) < LooseVersion('1.8')
+
+
+WARNING_TEMPLATE = """
+Note: The static directory '{0}' was not found. If you don't need it then make
+      sure it isn't included in the html_static_path setting in your conf.py
+      file, otherwise Sphinx may fail the build if you are turning warnings into
+      errors.
+"""
+
+
+def static_warning(app, config=None):
+
+    if SPHINX_LT_16:
+        info = app.info
+    else:
+        from sphinx.util import logging
+        info = logging.getLogger(__name__).info
+
+    for directory in app.config.html_static_path:
+        if not os.path.exists(directory):
+            info(WARNING_TEMPLATE.format(directory))
+
+
+def setup(app):
+    app.connect('build-finished', static_warning)

--- a/sphinx_astropy/tests/test_conf.py
+++ b/sphinx_astropy/tests/test_conf.py
@@ -5,7 +5,16 @@ from sphinx import __version__
 SPHINX_LT_17 = LooseVersion(__version__) < LooseVersion('1.7')
 
 if SPHINX_LT_17:
-    from sphinx import build_main
+
+    from sphinx import build_main as build_main_original
+
+    # As of Sphinx 1.7, the first argument is now no longer ignored, so we
+    # construct a wrapper for older versions.
+
+    def build_main(argv=None):
+        argv.insert(0, 'sphinx-build')
+        build_main_original(argv=argv)
+
 else:
     from sphinx.cmd.build import build_main
 
@@ -22,9 +31,7 @@ Just a test
 """
 
 
-def test_conf(tmpdir):
-
-    # Just make sure the docs build with the default sphinx-astropy configuration
+def generate_files(tmpdir):
 
     with open(tmpdir.join('conf.py').strpath, 'w') as f:
         f.write(BASIC_CONF)
@@ -32,13 +39,34 @@ def test_conf(tmpdir):
     with open(tmpdir.join('index.rst').strpath, 'w') as f:
         f.write(BASIC_INDEX)
 
+
+def test_conf(tmpdir):
+
+    # Just make sure the docs build with the default sphinx-astropy configuration
+
+    generate_files(tmpdir)
+
     src_dir = tmpdir.strpath
     html_dir = tmpdir.mkdir('html').strpath
 
-    if SPHINX_LT_17:
-        status = build_main(argv=['sphinx-build', '-W', '-b', 'html', src_dir, html_dir])
-    else:
-        # As of Sphinx 1.7, the first argument is now no longer ignored
-        status = build_main(argv=['-W', '-b', 'html', src_dir, html_dir])
+    status = build_main(argv=['-W', '-b', 'html', src_dir, html_dir])
 
     assert status == 0
+
+
+def test_intersphinx_toggle(tmpdir, capsys):
+
+    # Test the sphinx_astropy.ext.intersphinx_toggle extension
+
+    generate_files(tmpdir)
+
+    src_dir = tmpdir.strpath
+    html_dir = tmpdir.mkdir('html').strpath
+
+    status = build_main(argv=['-W', '-b', 'html', src_dir, html_dir, '-D', 'disable_intersphinx=1'])
+
+    assert status == 0
+
+    captured = capsys.readouterr()
+    assert 'disabling intersphinx' in captured.out
+    assert 'loading intersphinx' not in captured.out

--- a/sphinx_astropy/tests/test_conf.py
+++ b/sphinx_astropy/tests/test_conf.py
@@ -13,14 +13,14 @@ if SPHINX_LT_17:
 
     def build_main(argv=None):
         argv.insert(0, 'sphinx-build')
-        build_main_original(argv=argv)
+        return build_main_original(argv=argv)
 
 else:
     from sphinx.cmd.build import build_main
 
-
 BASIC_CONF = """
 from sphinx_astropy.conf import *
+suppress_warnings = ['app.add_directive', 'app.add_node']
 """
 
 BASIC_INDEX = """

--- a/sphinx_astropy/tests/test_conf.py
+++ b/sphinx_astropy/tests/test_conf.py
@@ -20,7 +20,7 @@ else:
 
 BASIC_CONF = """
 from sphinx_astropy.conf import *
-suppress_warnings = ['app.add_directive', 'app.add_node']
+suppress_warnings = ['app.add_directive', 'app.add_node', 'app.add_role']
 """
 
 BASIC_INDEX = """


### PR DESCRIPTION
*Background:* astropy-helpers needs a way to enable/disable intersphinx from the command-line (see e.g. https://github.com/astropy/astropy-helpers/pull/413) without touching ``conf.py``.

``sphinx-build`` has a ``-D`` option that can be used to override sphinx configuration values. Unfortunately, one can't do ``-D intersphinx_mapping={}`` for example. Instead, this produces the following error:

```
cannot override dictionary config setting 'intersphinx_mapping', ignoring (use 'intersphinx_mapping.key=value' to set individual elements)
```

This PR adds a mini extension to sphinx-astropy that means that we can simply do:

```
sphinx-build ... -D disable_intersphinx=1
```

We'll then be able to use this in astropy-helpers to control whether intersphinx is used or not.