### PR TITLE
Fix app.info() deprecation warning for Sphinx >= 1.6

### DIFF
--- a/sphinx_astropy/ext/changelog_links.py
+++ b/sphinx_astropy/ext/changelog_links.py
@@ -7,8 +7,12 @@ GitHub issues.
 from __future__ import print_function
 
 import re
-
+from distutils.version import LooseVersion
 from docutils.nodes import Text, reference
+
+from sphinx import __version__
+
+SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
 
 BLOCK_PATTERN = re.compile('\[#.+\]', flags=re.DOTALL)
 ISSUE_PATTERN = re.compile('#[0-9]+')
@@ -22,7 +26,13 @@ def process_changelog_links(app, doctree, docname):
         # if the doc doesn't match any of the changelog regexes, don't process
         return
 
-    app.info('[changelog_links] Adding changelog links to "{0}"'.format(docname))
+    if SPHINX_LT_16:
+        info = app.info
+    else:
+        from sphinx.util import logging
+        info = logging.getLogger(__name__).info
+
+    info('[changelog_links] Adding changelog links to "{0}"'.format(docname))
 
     for item in doctree.traverse():
 


### PR DESCRIPTION
Fix for the deprecation warning seen while building docs:
```
RemovedInSphinx20Warning: app.info() is now deprecated. Use sphinx.util.logging instead.
  app.info('[changelog_links] Adding changelog links to "{0}"'.format(docname))
```