### PR TITLE
Add an example directive to mark in-text examples for the example gallery

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changes in sphinx-astropy
 - Updated minimum required version of Sphinx to 1.6 as Numpydoc dropped
   suport for older ones. [#19]
 
+- Added an ``example`` directive to mark example snippets in documentation
+  text. These examples are republished in an example gallery. [#22]
+
 1.1.1 (2019-02-21)
 ------------------
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+pytest_plugins = ('sphinx.testing.fixtures',)
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "sphinx(builder, testroot='name'): Run sphinx on a site"
+    )

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -133,7 +133,8 @@ extensions = [
     'sphinx_astropy.ext.doctest',
     'sphinx_astropy.ext.changelog_links',
     'sphinx_astropy.ext.missing_static',
-    'sphinx.ext.mathjax']
+    'sphinx.ext.mathjax',
+    'sphinx_astropy.ext.example']
 
 try:
     import matplotlib.sphinxext.plot_directive

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -133,8 +133,8 @@ extensions = [
     'sphinx_astropy.ext.doctest',
     'sphinx_astropy.ext.changelog_links',
     'sphinx_astropy.ext.missing_static',
-    'sphinx.ext.mathjax',
-    'sphinx_astropy.ext.example']
+    'sphinx_astropy.ext.example',
+    'sphinx.ext.mathjax']
 
 try:
     import matplotlib.sphinxext.plot_directive

--- a/sphinx_astropy/ext/example/__init__.py
+++ b/sphinx_astropy/ext/example/__init__.py
@@ -10,7 +10,7 @@ __all__ = ('setup',)
 
 from pkg_resources import get_distribution
 
-from .marker import ExampleMarkerDirective, purge_examples
+from .marker import ExampleMarkerDirective, purge_examples, merge_examples
 
 
 def setup(app):
@@ -30,6 +30,7 @@ def setup(app):
     """
     app.add_directive('example', ExampleMarkerDirective)
     app.connect('env-purge-doc', purge_examples)
+    app.connect('env-merge-info', merge_examples)
 
     return {'version': get_distribution('sphinx_astropy').version,
             # env_version needs to be incremented when the persisted data

--- a/sphinx_astropy/ext/example/__init__.py
+++ b/sphinx_astropy/ext/example/__init__.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Example gallery Sphinx extension.
+
+Use the ``example`` directive to mark standalone examples where they appear in
+the documentation. Other directives (to be built) index and render those
+examples in a centralized example gallery.
+"""
+
+__all__ = ('setup',)
+
+from pkg_resources import get_distribution
+
+
+def setup(app):
+    """Set up the example gallery Sphinx extensions.
+
+    Parameters
+    ----------
+    app
+        The Sphinx application.
+
+    Returns
+    -------
+    metadata : `dict`
+        Dictionary with extension metadata. See
+        http://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata
+        for more information.
+    """
+    return {'version': get_distribution('sphinx_astropy').version,
+            # env_version needs to be incremented when the persisted data
+            # formats of the extension change.
+            'env_version': 1,
+            'parallel_read_safe': True,
+            'parallel_write_safe': True}

--- a/sphinx_astropy/ext/example/__init__.py
+++ b/sphinx_astropy/ext/example/__init__.py
@@ -10,7 +10,7 @@ __all__ = ('setup',)
 
 from pkg_resources import get_distribution
 
-from .marker import ExampleMarkerDirective
+from .marker import ExampleMarkerDirective, purge_examples
 
 
 def setup(app):
@@ -29,6 +29,7 @@ def setup(app):
         for more information.
     """
     app.add_directive('example', ExampleMarkerDirective)
+    app.connect('env-purge-doc', purge_examples)
 
     return {'version': get_distribution('sphinx_astropy').version,
             # env_version needs to be incremented when the persisted data

--- a/sphinx_astropy/ext/example/__init__.py
+++ b/sphinx_astropy/ext/example/__init__.py
@@ -10,6 +10,8 @@ __all__ = ('setup',)
 
 from pkg_resources import get_distribution
 
+from .marker import ExampleMarkerDirective
+
 
 def setup(app):
     """Set up the example gallery Sphinx extensions.
@@ -26,6 +28,8 @@ def setup(app):
         http://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata
         for more information.
     """
+    app.add_directive('example', ExampleMarkerDirective)
+
     return {'version': get_distribution('sphinx_astropy').version,
             # env_version needs to be incremented when the persisted data
             # formats of the extension change.

--- a/sphinx_astropy/ext/example/marker.py
+++ b/sphinx_astropy/ext/example/marker.py
@@ -3,7 +3,7 @@
 text.
 """
 
-__all__ = ('ExampleMarkerDirective', 'purge_examples')
+__all__ = ('ExampleMarkerDirective', 'purge_examples', 'merge_examples')
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -121,6 +121,32 @@ def purge_examples(app, env, docname):
     env.sphinx_astropy_examples = {
         id_: example for id_, example in env.sphinx_astropy_examples.items()
         if example['docname'] != docname}
+
+
+def merge_examples(app, env, docnames, other):
+    """Merge ``env.sphinx_astropy_examples`` from parallel document reads
+    during the ``env-merge-info`` event.
+
+    Parameters
+    ----------
+    app : sphinx.application.Sphinx
+        The app instance.
+    env : sphinx.environment.BuildEnvironment
+        The build environment (modified in place).
+    docname : str
+        Name of the document behing purged during a ``env-purge-doc`` event.
+    other : sphinx.environment.BuildEnvironment
+        The build environment from the *other* parallel process.
+    """
+    if not hasattr(other, 'sphinx_astropy_examples'):
+        return
+    if not hasattr(env, 'sphinx_astropy_examples'):
+        env.sphinx_astropy_examples = {}
+
+    for example_id, example in other.sphinx_astropy_examples.items():
+        _check_for_existing_example(env, example_id, example['docname'],
+                                    example['lineno'], example['title'])
+        env.sphinx_astropy_examples[example_id] = example
 
 
 def _check_for_existing_example(env, example_id, docname, lineno, title):

--- a/sphinx_astropy/ext/example/marker.py
+++ b/sphinx_astropy/ext/example/marker.py
@@ -3,7 +3,7 @@
 text.
 """
 
-__all__ = ('ExampleMarkerDirective',)
+__all__ = ('ExampleMarkerDirective', 'purge_examples')
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -131,3 +131,25 @@ class ExampleMarkerDirective(Directive):
                 raise SphinxError(
                     'There is already an example titled "{self.title}" '
                     '({env.docname}:{self.lineno})'.format(self=self, env=env))
+
+
+def purge_examples(app, env, docname):
+    """Remove examples from ``env.sphinx_astropy_examples`` during the
+    ``env-purge-doc`` event because an associated document was removed from
+    the doctree.
+
+    Parameters
+    ----------
+    app : sphinx.application.Sphinx
+        The app instance.
+    env : sphinx.environment.BuildEnvironment
+        The build environment (modified in place).
+    docname : str
+        Name of the document behing purged during a ``env-purge-doc`` event.
+    """
+    if not hasattr(env, 'sphinx_astropy_examples'):
+        return
+    # Filter out examples matching the purged docname
+    env.sphinx_astropy_examples = {
+        id_: example for id_, example in env.sphinx_astropy_examples.items()
+        if example['docname'] != docname}

--- a/sphinx_astropy/ext/example/marker.py
+++ b/sphinx_astropy/ext/example/marker.py
@@ -61,7 +61,7 @@ class ExampleMarkerDirective(Directive):
         if self.example_id in env.sphinx_astropy_examples:
             raise SphinxError(
                 'There is already an example titled "{self.title}" '
-                '({self.docname:self.lineno})'.format(self=self.title))
+                '({env.docname}:{self.lineno})'.format(self=self, env=env))
 
         # Parse tags, which are comma-separated.
         if 'tags' in self.options:

--- a/sphinx_astropy/ext/example/marker.py
+++ b/sphinx_astropy/ext/example/marker.py
@@ -15,7 +15,7 @@ from sphinx.util.nodes import nested_parse_with_titles
 class ExampleMarkerDirective(Directive):
     """Directive for marking an example snippet in the body of documentation.
 
-    This directive passes content through, unaffected, into the original
+    This directive passes content through into the original
     documentation, but also indexes and copies the content to appear in an
     example gallery.
 
@@ -82,6 +82,11 @@ class ExampleMarkerDirective(Directive):
         container_node.document = self.state.document
         nested_parse_with_titles(self.state, self.content, container_node)
 
+        # The target node is for backlinks from an example page to the
+        # source of the example in the "main" docs.
+        target_node = nodes.target('', '', ids=[self.example_id])
+        self.state.document.note_explicit_target(target_node)
+
         # Persist the example for post-processing into the gallery
         env.sphinx_astropy_examples[self.example_id] = {
             'docname': env.docname,
@@ -91,4 +96,7 @@ class ExampleMarkerDirective(Directive):
             'content': self.content
         }
 
-        return container_node.children
+        output_nodes = [target_node]
+        output_nodes.extend(container_node.children)
+
+        return output_nodes

--- a/sphinx_astropy/ext/example/marker.py
+++ b/sphinx_astropy/ext/example/marker.py
@@ -1,0 +1,94 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""The ``example`` directive that marks examples in the main documentation
+text.
+"""
+
+__all__ = ('ExampleMarkerDirective',)
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+from sphinx.errors import SphinxError
+from sphinx.util.logging import getLogger
+from sphinx.util.nodes import nested_parse_with_titles
+
+
+class ExampleMarkerDirective(Directive):
+    """Directive for marking an example snippet in the body of documentation.
+
+    This directive passes content through, unaffected, into the original
+    documentation, but also indexes and copies the content to appear in an
+    example gallery.
+
+    Usage example:
+
+    .. code-block:: rst
+
+       .. example:: Title of Example
+          :tags: tag-1, tag-2
+
+          Example content.
+
+          The example content can contain multiple paragraphs, lists, images,
+          code blocks, equations, and so on.
+
+    Tags are optional and comma-separated.
+    """
+
+    _logger = getLogger(__name__)
+
+    has_content = True
+
+    required_arguments = 1  # The title is required
+    final_argument_whitespace = True
+
+    option_spec = {
+        'tags': directives.unchanged
+    }
+
+    def run(self):
+        self.assert_has_content()
+
+        env = self.state.document.settings.env
+
+        # Examples are stored under the Sphinx_astropy_example attribute of
+        # the environment.
+        if not hasattr(env, 'sphinx_astropy_examples'):
+            env.sphinx_astropy_examples = {}
+
+        self.title = self.arguments[0].strip()
+
+        self.example_id = '-'.join(('example-src', nodes.make_id(self.title)))
+        if self.example_id in env.sphinx_astropy_examples:
+            raise SphinxError(
+                'There is already an example titled "{self.title}" '
+                '({self.docname:self.lineno})'.format(self=self.title))
+
+        # Parse tags, which are comma-separated.
+        if 'tags' in self.options:
+            self.tags = set([t.strip()
+                             for t in self.options['tags'].split(',')])
+        else:
+            self.tags = set()
+
+        self._logger.debug(
+            '[sphinx_astropy] example title: %s, tags: %s',
+            self.title, self.tags, location=(env.docname, self.lineno))
+
+        # The container_node is just for nested parsing on the directive's
+        # content. Only its children get added back into the node tree of
+        # the original documentation page.
+        container_node = nodes.container(rawsource='\n'.join(self.content))
+        # For docname/lineno metadata
+        container_node.document = self.state.document
+        nested_parse_with_titles(self.state, self.content, container_node)
+
+        # Persist the example for post-processing into the gallery
+        env.sphinx_astropy_examples[self.example_id] = {
+            'docname': env.docname,
+            'lineno': self.lineno,
+            'title': self.title,
+            'tags': self.tags,
+            'content': self.content
+        }
+
+        return container_node.children

--- a/sphinx_astropy/tests/conftest.py
+++ b/sphinx_astropy/tests/conftest.py
@@ -1,0 +1,14 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import pytest
+from sphinx.testing.path import path
+
+# Exclude 'roots' dirs for pytest test collector
+collect_ignore = ['roots']
+
+
+@pytest.fixture(scope='session')
+def rootdir():
+    """Directory containing Sphinx projects for testing.
+    """
+    return path(__file__).parent.abspath() / 'roots'

--- a/sphinx_astropy/tests/example_module/example.py
+++ b/sphinx_astropy/tests/example_module/example.py
@@ -1,0 +1,21 @@
+"""This module demonstrates using the ``example`` directive in docstrings.
+"""
+
+__all__ = ('example_func',)
+
+
+def example_func():
+    """A function with an example in its docstring.
+
+    Examples
+    --------
+
+    .. example:: Using example_func
+       :tags: tag-a
+
+       An example marked up with the ``example`` directive.
+
+       >>> example_func()
+       True
+    """
+    return True

--- a/sphinx_astropy/tests/roots/test-example-gallery-duplicates/conf.py
+++ b/sphinx_astropy/tests/roots/test-example-gallery-duplicates/conf.py
@@ -1,0 +1,3 @@
+master_doc = 'index'  # for Sphinx <2.0
+extensions = ['sphinx_astropy.ext.example']
+exclude_patterns = ['_build']

--- a/sphinx_astropy/tests/roots/test-example-gallery-duplicates/conf.py
+++ b/sphinx_astropy/tests/roots/test-example-gallery-duplicates/conf.py
@@ -1,3 +1,4 @@
 master_doc = 'index'  # for Sphinx <2.0
 extensions = ['sphinx_astropy.ext.example']
 exclude_patterns = ['_build']
+suppress_warnings = ['app.add_directive', 'app.add_node']

--- a/sphinx_astropy/tests/roots/test-example-gallery-duplicates/duplicate-examples.rst
+++ b/sphinx_astropy/tests/roots/test-example-gallery-duplicates/duplicate-examples.rst
@@ -1,0 +1,7 @@
+Page with duplicate examples
+============================
+
+.. example:: Tagged example
+   :tags: tag-a
+
+   This example has a title that duplicates an example in examples.rst. Building with this file should trigger an exception.

--- a/sphinx_astropy/tests/roots/test-example-gallery-duplicates/examples.rst
+++ b/sphinx_astropy/tests/roots/test-example-gallery-duplicates/examples.rst
@@ -1,0 +1,15 @@
+Page with examples
+==================
+
+.. example:: Example with two paragraphs
+
+   This is the first paragraph.
+
+   And the second paragraph.
+
+This content isn't part of an example.
+
+.. example:: Tagged example
+   :tags: tag-a
+
+   This example is tagged with ``tag-a``.

--- a/sphinx_astropy/tests/roots/test-example-gallery/conf.py
+++ b/sphinx_astropy/tests/roots/test-example-gallery/conf.py
@@ -5,3 +5,4 @@ extensions = [
     'sphinx_astropy.ext.example'
 ]
 exclude_patterns = ['_build']
+suppress_warnings = ['app.add_directive', 'app.add_node']

--- a/sphinx_astropy/tests/roots/test-example-gallery/conf.py
+++ b/sphinx_astropy/tests/roots/test-example-gallery/conf.py
@@ -1,0 +1,3 @@
+master_doc = 'index'  # for Sphinx <2.0
+extensions = ['sphinx_astropy.ext.example']
+exclude_patterns = ['_build']

--- a/sphinx_astropy/tests/roots/test-example-gallery/conf.py
+++ b/sphinx_astropy/tests/roots/test-example-gallery/conf.py
@@ -1,3 +1,7 @@
 master_doc = 'index'  # for Sphinx <2.0
-extensions = ['sphinx_astropy.ext.example']
+extensions = [
+    'sphinx.ext.autodoc',
+    'numpydoc',
+    'sphinx_astropy.ext.example'
+]
 exclude_patterns = ['_build']

--- a/sphinx_astropy/tests/roots/test-example-gallery/example-marker.rst
+++ b/sphinx_astropy/tests/roots/test-example-gallery/example-marker.rst
@@ -1,0 +1,44 @@
+Page with an example
+====================
+
+This content isn't part of the example.
+
+.. example:: Example with two paragraphs
+
+   This is the first paragraph.
+
+   And the second paragraph.
+
+This content isn't part of an example.
+
+.. example:: Tagged example
+   :tags: tag-a
+
+   This example is tagged with ``tag-a``.
+
+This content isn't part of an example.
+
+.. example:: Example with multiple tags
+   :tags: tag-a, tag-b
+
+   This example is tagged with ``tag-a`` and ``tag-b``.
+
+This content isn't part of an example.
+
+.. example:: Example with subsections
+   :tags: tag-b
+
+   Example with subsections
+   ------------------------
+
+   This example starts with a header.
+
+   Subsubsection
+   ^^^^^^^^^^^^^
+
+   This is the first subsubsection.
+
+   Second subsubsection
+   ^^^^^^^^^^^^^^^^^^^^
+
+   This is the second subsubsection.

--- a/sphinx_astropy/tests/roots/test-example-gallery/example_func.rst
+++ b/sphinx_astropy/tests/roots/test-example-gallery/example_func.rst
@@ -1,0 +1,6 @@
+example\_func
+=============
+ 
+ .. currentmodule:: sphinx_astropy.tests.example_module.example
+ 
+ .. autofunction:: example_func

--- a/sphinx_astropy/tests/roots/test-example-gallery/index.rst
+++ b/sphinx_astropy/tests/roots/test-example-gallery/index.rst
@@ -1,0 +1,7 @@
+test-example-gallery
+====================
+
+.. toctree::
+   :glob:
+
+   *

--- a/sphinx_astropy/tests/test_example.py
+++ b/sphinx_astropy/tests/test_example.py
@@ -1,0 +1,30 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from xml.etree.ElementTree import tostring
+
+import pytest
+from sphinx.testing.util import etree_parse
+
+# Sphinx pytest fixtures only available in Sphinx 1.7+
+pytest.importorskip("sphinx", minversion="1.7")
+
+
+@pytest.mark.sphinx('xml', testroot='example-gallery')
+def test_example_directive_targets(app, status, warning):
+    """Test that the example directive creates target nodes with the
+    appropriate Ids.
+    """
+    app.builder.build(['example-marker'])
+    et = etree_parse(app.outdir / 'example-marker.xml')
+    print(tostring(et.getroot(), encoding='unicode'))
+
+    known_target_refids = [
+        'example-src-example-with-two-paragraphs',
+        'example-src-tagged-example',
+        'example-src-example-with-multiple-tags',
+        'example-src-example-with-subsections'
+    ]
+    targets = et.findall('*target')
+    target_refids = [t.attrib['refid'] for t in targets]
+    for known_target_refid in known_target_refids:
+        assert known_target_refid in target_refids

--- a/sphinx_astropy/tests/test_example.py
+++ b/sphinx_astropy/tests/test_example.py
@@ -4,6 +4,7 @@ from xml.etree.ElementTree import tostring
 
 import pytest
 from sphinx.testing.util import etree_parse
+from sphinx.util import logging
 from sphinx.errors import SphinxError
 
 # Sphinx pytest fixtures only available in Sphinx 1.7+
@@ -15,7 +16,10 @@ def test_example_directive_targets(app, status, warning):
     """Test that the example directive creates target nodes with the
     appropriate Ids.
     """
-    app.builder.build(['example-marker'])
+    app.verbosity = 2
+    logging.setup(app, status, warning)
+    app.builder.build_all()
+
     et = etree_parse(app.outdir / 'example-marker.xml')
     print(tostring(et.getroot(), encoding='unicode'))
 
@@ -35,7 +39,10 @@ def test_example_directive_targets(app, status, warning):
 def test_example_env_persistence(app, status, warning):
     """Test that the examples are added to the app env.
     """
-    app.builder.build(['example-marker'])
+    app.verbosity = 2
+    logging.setup(app, status, warning)
+    app.builder.build_all()
+
     assert hasattr(app.env, 'sphinx_astropy_examples')
     examples = app.env.sphinx_astropy_examples
 

--- a/sphinx_astropy/tests/test_example.py
+++ b/sphinx_astropy/tests/test_example.py
@@ -28,3 +28,40 @@ def test_example_directive_targets(app, status, warning):
     target_refids = [t.attrib['refid'] for t in targets]
     for known_target_refid in known_target_refids:
         assert known_target_refid in target_refids
+
+
+@pytest.mark.sphinx('dummy', testroot='example-gallery')
+def test_example_env_persistence(app, status, warning):
+    """Test that the examples are added to the app env.
+    """
+    app.builder.build(['example-marker'])
+    assert hasattr(app.env, 'sphinx_astropy_examples')
+    examples = app.env.sphinx_astropy_examples
+
+    known_examples = [
+        'example-src-example-with-two-paragraphs',
+        'example-src-tagged-example',
+        'example-src-example-with-multiple-tags',
+        'example-src-example-with-subsections'
+    ]
+    for k in known_examples:
+        assert k in examples
+
+    # Test tags
+    assert examples['example-src-example-with-two-paragraphs']['tags'] == set()
+    assert examples['example-src-tagged-example']['tags'] == set(['tag-a'])
+    assert examples['example-src-example-with-multiple-tags']['tags'] \
+        == set(['tag-a', 'tag-b'])
+
+    ex = examples['example-src-example-with-two-paragraphs']
+
+    # Test title
+    assert ex['title'] == 'Example with two paragraphs'
+
+    # Test docname
+    assert ex['docname'] == 'example-marker'
+
+    # Test content
+    assert str(ex['content'][0]) == 'This is the first paragraph.'
+    assert str(ex['content'][1]) == ''
+    assert str(ex['content'][2]) == 'And the second paragraph.'

--- a/sphinx_astropy/tests/test_example.py
+++ b/sphinx_astropy/tests/test_example.py
@@ -4,6 +4,7 @@ from xml.etree.ElementTree import tostring
 
 import pytest
 from sphinx.testing.util import etree_parse
+from sphinx.errors import SphinxError
 
 # Sphinx pytest fixtures only available in Sphinx 1.7+
 pytest.importorskip("sphinx", minversion="1.7")
@@ -65,3 +66,13 @@ def test_example_env_persistence(app, status, warning):
     assert str(ex['content'][0]) == 'This is the first paragraph.'
     assert str(ex['content'][1]) == ''
     assert str(ex['content'][2]) == 'And the second paragraph.'
+
+
+@pytest.mark.sphinx('dummy', testroot='example-gallery-duplicates')
+def test_example_directive_duplicates(app, status, warning):
+    """The example-gallery-duplicates test case has examples with the same
+    title, which is disallowed.
+    """
+    expected_message = r'^There is already an example titled "Tagged example"'
+    with pytest.raises(SphinxError, match=expected_message):
+        app.builder.build(['examples', 'duplicate-examples'])

--- a/sphinx_astropy/tests/test_example.py
+++ b/sphinx_astropy/tests/test_example.py
@@ -2,7 +2,6 @@
 
 from xml.etree.ElementTree import tostring
 
-from docutils import nodes
 import pytest
 from sphinx.testing.util import etree_parse
 from sphinx.util import logging


### PR DESCRIPTION
This PR is the first part of the example gallery work described in astropy/astropy#7242. It adds an `example` directive that marks examples in documentation text. For example:

```rst
.. example:: Title of the example
   :tags: first-tag, another-tag

   Content of the example.

   More content in the example.

This content is not part of the example.
```

The example directive does not change the visual appearance of the example content in the documentation text, but it does record the example in the build environment so that it can be republished in the example gallery (work to be done).

## Example metadata

Internally, the example directive stores examples in the build environment under the `sphinx_astropy_examples` attribute. Examples are keyed by `example-src-*slugified-title*` and metadata for each example consists of:

- `title`
- `tags` (set of tag strings)
- `contents` (unparsed content of the directive)
- `docname`
- `lineno`

## Target node

The example directive also adds a `target` node to the start of the example content in the original content source. This will make it possible to backlink to the original source of the example.

## Testing

For this work I'm using the same testing strategy that Sphinx is using for its extensions. The idea is that we add mock Sphinx projects to `sphinx_astropy/tests/roots`. Each subdirectory is an isolated example site. These sites are associated with a test module. Test functions use a `pytest.mark.sphinx` directive to do isolated Sphinx builds where we can test the output in various formats (html, latex, xml, or "dummy" to just see docutils nodes):

```py
@pytest.mark.sphinx('dummy', testroot='example-gallery')
def test_example_env_persistence(app, status, warning):
    """Test that the examples are added to the app env.
    """
    app.builder.build(['docname'])
   # test code...
```

The downside of this test strategy is that it doesn't work (as far as I can tell) with Sphinx 1.6, so I'm having pytest ignore these tests in the Sphinx 1.6 build. I suggest this trade-off is ok because it makes it convenient to realistically test Sphinx extensions in all newer versions of Sphinx.