### PR TITLE
Mark two extensions as parallel-safe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changes in sphinx-astropy
   support for Sphinx older than 1.6 and the inherit docstring feature is
   only available in Sphinx 1.7 or greater. [#19, #24]
 
+- Make sure all extensions are marked as parallel-safe. [#26]
+
 1.1.1 (2019-02-21)
 ------------------
 

--- a/sphinx_astropy/ext/intersphinx_toggle.py
+++ b/sphinx_astropy/ext/intersphinx_toggle.py
@@ -42,3 +42,6 @@ def setup(app):
         app.connect('config-inited', disable_intersphinx)
 
     app.add_config_value('disable_intersphinx', 0, True)
+
+    return {'parallel_read_safe': True,
+            'parallel_write_safe': True}

--- a/sphinx_astropy/ext/missing_static.py
+++ b/sphinx_astropy/ext/missing_static.py
@@ -35,4 +35,8 @@ def static_warning(app, config=None):
 
 
 def setup(app):
+
     app.connect('build-finished', static_warning)
+
+    return {'parallel_read_safe': True,
+            'parallel_write_safe': True}


### PR DESCRIPTION
Without this, the astropy docs can't be built in parallel