### PR TITLE
Remove latex preamble section redefining warnings and notes

### DIFF
--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -298,14 +298,6 @@ latex_elements['preamble'] = r"""
 \DeclareUnicodeCharacter{00B0}{\ensuremath{^{\circ}}}
 \DeclareUnicodeCharacter{2032}{\ensuremath{^{\prime}}}
 \DeclareUnicodeCharacter{2033}{\ensuremath{^{\prime\prime}}}
-
-% Make the "warning" and "notes" sections use a sans-serif font to
-% make them stand out more.
-\renewenvironment{notice}[2]{
-  \def\py@noticetype{#1}
-  \csname py@noticestart@#1\endcsname
-  \textsf{\textbf{#2}}
-}{\csname py@noticeend@\py@noticetype\endcsname}
 """
 
 # Documents to append as an appendix to all manuals.


### PR DESCRIPTION
Sphinx `latexpdf` builds currently fail for packages that use `sphinx-astropy`.  I tracked this down to a section in the latex preamble that attempts to redefine the `notice` environment to change the font in Sphinx warnings and notes.  `Sphinx` no longer uses the `normal` environment, thus it would fail when rendering the tex file:

```
! LaTeX Error: Environment notice undefined.
l.109 \renewenvironment{notice}
```

The new name for this environment is called `sphinxadmonition`.  Renaming `notice` to `sphinxadmonition` fixes the issue, but instead I've simply removed the section redefining the environment.  The default `sphinxadmonition` now has horizontal lines around the warnings/notes sections, which help call out these sections.  IMHO, the Sphinx `sphinxadmonition` environments looks fine (and looks better than the overrides):

Sphinx Default (the result of this PR):

<img width="482" alt="removed" src="https://user-images.githubusercontent.com/4992897/95768087-c4fb8880-0c83-11eb-85fa-495dd04eacfc.png">

With custom override defined in `sphinx-astropy` to change the font to sans-serif (also removes horizontal lines):

<img width="442" alt="sphinxadmonition" src="https://user-images.githubusercontent.com/4992897/95768118-cfb61d80-0c83-11eb-81e4-aba393bbc0a1.png">


