### PR TITLE
MNT: Replace master with main

### DIFF
--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -69,8 +69,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents. Set to the "smart" one.

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -69,8 +69,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The main toctree document.
-main_doc = 'index'
+# The master toctree document.
+master_doc = 'index'
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents. Set to the "smart" one.

--- a/sphinx_astropy/ext/edit_on_github.py
+++ b/sphinx_astropy/ext/edit_on_github.py
@@ -16,7 +16,7 @@ It has the following configuration options (to be set in the project's
 * ``edit_on_github_branch``
     The name of the branch to edit.  If this is a released version,
     this should be a git tag referring to that version.  For a
-    dev version, it often makes sense for it to be "master".  It
+    dev version, it often makes sense for it to be "main".  It
     may also be a git hash.
 
 * ``edit_on_github_source_root``
@@ -149,7 +149,7 @@ def html_page_context(app, pagename, templatename, context, doctree):
 def setup(app):
 
     app.add_config_value('edit_on_github_project', 'REQUIRED', True)
-    app.add_config_value('edit_on_github_branch', 'master', True)
+    app.add_config_value('edit_on_github_branch', 'main', True)
     app.add_config_value('edit_on_github_source_root', 'lib', True)
     app.add_config_value('edit_on_github_doc_root', 'doc', True)
     app.add_config_value('edit_on_github_docstring_message',


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.