### PR TITLE
intersphinx xref

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ install_requires =
     sphinx-automodapi
     sphinx-gallery
     pillow
+
+[options.extras_require]
+all =
     astropy
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
 	sphinx-automodapi
 	sphinx-gallery
 	pillow
+    astropy
 
 [options.package_data]
 sphinx_astropy = local/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,12 +22,12 @@ universal = 1
 zip_safe = False
 packages = find:
 install_requires =
-	sphinx>=1.7
-	astropy-sphinx-theme
-	numpydoc
-	sphinx-automodapi
-	sphinx-gallery
-	pillow
+    sphinx>=1.7
+    astropy-sphinx-theme
+    numpydoc
+    sphinx-automodapi
+    sphinx-gallery
+    pillow
     astropy
 
 [options.package_data]

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -116,6 +116,30 @@ numpydoc_xref_aliases = {
     "mapping": ":term:`python:mapping`",
 }
 
+# Aliases to Astropy's glossary. In packages these can be turned on with
+# ``numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_glossary)``
+# (if astropy is in the intersphinx mapping).
+numpydoc_xref_aliases_astropy_glossary = {}  # works even if older astropy
+if float(astropy.__version__[:3]) >= 4.3:
+    numpydoc_xref_aliases_astropy_glossary = {
+        # general
+        "-like": ":term:`astropy:-like`",
+        # "number": ":term:`number`",
+        # "writable": ":term:`writable file-like object`",
+        # "readable": ":term:`readable file-like object`",
+        # coordinates
+        "angle-like": ":term:`astropy:angle-like`",
+        "coordinate-like": ":term:`astropy:coordinate-like`",
+        "frame-like": ":term:`astropy:frame-like`",
+        # units
+        "unit-like": ":term:`astropy:unit-like`",
+        "quantity-like": ":term:`astropy:quantity-like`",
+        # table
+        "table-like": ":term:`astropy:table-like`",
+        # time
+        "time-like": ":term:`astropy:time-like`",
+    }
+
 # Aliases to Astropy's physical types. In packages these can be turned on with
 # ``numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_physical_type)``
 # (if astropy is in the intersphinx mapping).

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -109,9 +109,17 @@ numpydoc_xref_ignore = {
 # aliases/shortcuts used when specifying the types of parameters.
 # Numpy provides some defaults
 # https://github.com/numpy/numpydoc/blob/b352cd7635f2ea7748722f410a31f937d92545cc/numpydoc/xref.py#L62-L94
-# numpydoc_xref_aliases = {}
+numpydoc_xref_aliases = {
+    # Python terms
+    "function": ":term:`python:function`",
+    "iterator": ":term:`python:iterator`",
+    "mapping": ":term:`python:mapping`",
+}
 
-numpydoc_xref_aliases_astropy_physical_type = {}
+# Aliases to Astropy's physical types. In packages these can be turned on with
+# ``numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_physical_type)``
+# (if astropy is in the intersphinx mapping).
+numpydoc_xref_aliases_astropy_physical_type = {}  # works even if older astropy
 if float(astropy.__version__[:3]) >= 4.3:
 
     # TODO! refactor if #11678 is implemented
@@ -122,8 +130,8 @@ if float(astropy.__version__[:3]) >= 4.3:
             key = f"'{ptype}'"
             val = f":ref:`:ref: '{ptype}' <astropy:{ptype}>`"   # <= intersphinxed.
             numpydoc_xref_aliases_astropy_physical_type[key] = val
-    
-    del ptypes, key, val
+
+    del ptypes, key, val, _units_and_physical_types
 
 # -- Project information ------------------------------------------------------
 

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -11,6 +11,7 @@
 
 import os
 import warnings
+from collections import ChainMap
 
 from os import path
 
@@ -156,6 +157,16 @@ if float(astropy.__version__[:3]) >= 4.3:
             numpydoc_xref_aliases_astropy_physical_type[key] = val
 
     del ptypes, key, val, _units_and_physical_types
+
+
+# Convenient collection of all of astropy's options for numpydoc xref.
+# In packages all the astropy additions can be turned on with
+# ``numpydoc_xref_aliases.update(numpydoc_xref_astropy_aliases)``
+# (if astropy is in the intersphinx mapping).
+numpydoc_xref_astropy_aliases = ChainMap(  # important at the top
+    numpydoc_xref_aliases_astropy_glossary,
+    numpydoc_xref_aliases_astropy_physical_type
+)
 
 # -- Project information ------------------------------------------------------
 

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -88,6 +88,40 @@ rst_epilog = """
 
 suppress_warnings = ['app.add_directive', ]
 
+# -- NumpyDoc X-Ref ------------------------
+
+# Whether to create cross-references for the parameter types in the
+# Parameters, Other Parameters, Returns and Yields sections of the docstring.
+# Should be set = True in packages manually! included here as reference.
+# numpydoc_xref_param_type = False
+
+# Words not to cross-reference. Most likely, these are common words used in
+# parameter type descriptions that may be confused for classes of the same
+# name. This can be overwritten or modified in packages and is provided here for
+# convenience.
+numpydoc_xref_ignore = {
+    'type', 'optional', 'default', 'or', 'of', 'method', 'instance', "like",
+    "class", 'subclass', "keyword-only", "default", "thereof"
+}
+
+# Mappings to fully qualified paths (or correct ReST references) for the
+# aliases/shortcuts used when specifying the types of parameters.
+# Numpy provides some defaults
+# https://github.com/numpy/numpydoc/blob/b352cd7635f2ea7748722f410a31f937d92545cc/numpydoc/xref.py#L62-L94
+# numpydoc_xref_aliases = {}
+
+# TODO! refactor if #11678 is implemented
+from astropy.units.physical import _units_and_physical_types
+numpydoc_xref_aliases_astropy_physical_type = {}
+for _, ptypes in _units_and_physical_types:
+    ptypes = {ptypes} if isinstance(ptypes, str) else ptypes
+    for ptype in ptypes:
+        key = f"'{ptype}'"
+        val = f":ref:`:ref: '{ptype}' <astropy:{ptype}>`"   # <= intersphinxed.
+        numpydoc_xref_aliases_astropy_physical_type[key] = val
+
+del ptypes, key, val
+
 # -- Project information ------------------------------------------------------
 
 # There are two options for replacing |today|: either, you set today to some

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -25,6 +25,8 @@ except ImportError:
 else:
     ASTROPY_INSTALLED = True
 
+    from astropy.utils import minversion
+
 
 # -- General configuration ----------------------------------------------------
 
@@ -107,10 +109,9 @@ suppress_warnings = ['app.add_directive', ]
 # parameter type descriptions that may be confused for classes of the same
 # name. This can be overwritten or modified in packages and is provided here for
 # convenience.
-numpydoc_xref_ignore = {
-    "type", "optional", "default", "or", "of", "method", "instance",
-    "class", "subclass", "keyword-only", "default", "thereof",
-}
+numpydoc_xref_ignore = {"or", "of", "thereof",
+                        "default", "optional", "keyword-only",
+                        "instance", "type", "class", "subclass", "method"}
 
 # Mappings to fully qualified paths (or correct ReST references) for the
 # aliases/shortcuts used when specifying the types of parameters.
@@ -126,8 +127,8 @@ numpydoc_xref_aliases = {
 # Aliases to Astropy's glossary. In packages these can be turned on with
 # ``numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_glossary)``
 # (if astropy is in the intersphinx mapping).
-numpydoc_xref_aliases_astropy_glossary = {}  # works even if older Astropy
-if ASTROPY_INSTALLED and float(astropy.__version__[:3]) >= 4.3:
+numpydoc_xref_aliases_astropy_glossary = {}  # works even if no Astropy
+if ASTROPY_INSTALLED and minversion(astropy, "4.3"):
     numpydoc_xref_aliases_astropy_glossary = {
         # general
         "-like": ":term:`astropy:-like`",
@@ -147,8 +148,8 @@ if ASTROPY_INSTALLED and float(astropy.__version__[:3]) >= 4.3:
 # Aliases to Astropy's physical types. In packages these can be turned on with
 # ``numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_physical_type)``
 # (if astropy is in the intersphinx mapping).
-numpydoc_xref_aliases_astropy_physical_type = {}  # works even if older astropy
-if ASTROPY_INSTALLED and float(astropy.__version__[:3]) >= 4.3:
+numpydoc_xref_aliases_astropy_physical_type = {}  # works even if no astropy
+if ASTROPY_INSTALLED and minversion(astropy, "4.3"):
 
     from astropy.units.physical import _name_physical_mapping
     for ptype in _name_physical_mapping.keys():

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -14,6 +14,7 @@ import warnings
 
 from os import path
 
+import astropy
 import sphinx
 from distutils.version import LooseVersion
 
@@ -110,17 +111,19 @@ numpydoc_xref_ignore = {
 # https://github.com/numpy/numpydoc/blob/b352cd7635f2ea7748722f410a31f937d92545cc/numpydoc/xref.py#L62-L94
 # numpydoc_xref_aliases = {}
 
-# TODO! refactor if #11678 is implemented
-from astropy.units.physical import _units_and_physical_types
 numpydoc_xref_aliases_astropy_physical_type = {}
-for _, ptypes in _units_and_physical_types:
-    ptypes = {ptypes} if isinstance(ptypes, str) else ptypes
-    for ptype in ptypes:
-        key = f"'{ptype}'"
-        val = f":ref:`:ref: '{ptype}' <astropy:{ptype}>`"   # <= intersphinxed.
-        numpydoc_xref_aliases_astropy_physical_type[key] = val
+if float(astropy.__version__[:3]) >= 4.3:
 
-del ptypes, key, val
+    # TODO! refactor if #11678 is implemented
+    from astropy.units.physical import _units_and_physical_types
+    for _, ptypes in _units_and_physical_types:
+        ptypes = {ptypes} if isinstance(ptypes, str) else ptypes
+        for ptype in ptypes:
+            key = f"'{ptype}'"
+            val = f":ref:`:ref: '{ptype}' <astropy:{ptype}>`"   # <= intersphinxed.
+            numpydoc_xref_aliases_astropy_physical_type[key] = val
+    
+    del ptypes, key, val
 
 # -- Project information ------------------------------------------------------
 

--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -15,9 +15,15 @@ from collections import ChainMap
 
 from os import path
 
-import astropy
 import sphinx
 from distutils.version import LooseVersion
+
+try:
+    import astropy
+except ImportError:
+    ASTROPY_INSTALLED = False
+else:
+    ASTROPY_INSTALLED = True
 
 
 # -- General configuration ----------------------------------------------------
@@ -102,8 +108,8 @@ suppress_warnings = ['app.add_directive', ]
 # name. This can be overwritten or modified in packages and is provided here for
 # convenience.
 numpydoc_xref_ignore = {
-    'type', 'optional', 'default', 'or', 'of', 'method', 'instance', "like",
-    "class", 'subclass', "keyword-only", "default", "thereof"
+    "type", "optional", "default", "or", "of", "method", "instance",
+    "class", "subclass", "keyword-only", "default", "thereof",
 }
 
 # Mappings to fully qualified paths (or correct ReST references) for the
@@ -120,14 +126,11 @@ numpydoc_xref_aliases = {
 # Aliases to Astropy's glossary. In packages these can be turned on with
 # ``numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_glossary)``
 # (if astropy is in the intersphinx mapping).
-numpydoc_xref_aliases_astropy_glossary = {}  # works even if older astropy
-if float(astropy.__version__[:3]) >= 4.3:
+numpydoc_xref_aliases_astropy_glossary = {}  # works even if older Astropy
+if ASTROPY_INSTALLED and float(astropy.__version__[:3]) >= 4.3:
     numpydoc_xref_aliases_astropy_glossary = {
         # general
         "-like": ":term:`astropy:-like`",
-        # "number": ":term:`number`",
-        # "writable": ":term:`writable file-like object`",
-        # "readable": ":term:`readable file-like object`",
         # coordinates
         "angle-like": ":term:`astropy:angle-like`",
         "coordinate-like": ":term:`astropy:coordinate-like`",
@@ -145,18 +148,14 @@ if float(astropy.__version__[:3]) >= 4.3:
 # ``numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_physical_type)``
 # (if astropy is in the intersphinx mapping).
 numpydoc_xref_aliases_astropy_physical_type = {}  # works even if older astropy
-if float(astropy.__version__[:3]) >= 4.3:
+if ASTROPY_INSTALLED and float(astropy.__version__[:3]) >= 4.3:
 
-    # TODO! refactor if #11678 is implemented
-    from astropy.units.physical import _units_and_physical_types
-    for _, ptypes in _units_and_physical_types:
-        ptypes = {ptypes} if isinstance(ptypes, str) else ptypes
-        for ptype in ptypes:
-            key = f"'{ptype}'"
-            val = f":ref:`:ref: '{ptype}' <astropy:{ptype}>`"   # <= intersphinxed.
-            numpydoc_xref_aliases_astropy_physical_type[key] = val
+    from astropy.units.physical import _name_physical_mapping
+    for ptype in _name_physical_mapping.keys():
+        val = f":ref:`:ref: '{ptype}' <astropy:{ptype}>`"   # <= intersphinxed
+        numpydoc_xref_aliases_astropy_physical_type[f"'{ptype}'"] = val
 
-    del ptypes, key, val, _units_and_physical_types
+    del ptype, val, _name_physical_mapping  # cleanup namespace
 
 
 # Convenient collection of all of astropy's options for numpydoc xref.


### PR DESCRIPTION
Signed-off-by: Nathaniel Starkman (@nstarman) <nstarkman@protonmail.com>

- Add section on numpydoc xref to v1.
- preload the xref ignore set. This can be modified or replaced in packages with standard set operations.
- Add ``numpydoc_xref_aliases_astropy_glossary``, an xref mapping that can be added to the ``numpydoc_xref_aliases`` in packages by dictionary updating. This is designed for easy inclusion of astropy's glossary.
- Add ``numpydoc_xref_aliases_astropy_physical_type``, an xref mapping that can be added to the ``numpydoc_xref_aliases`` in packages by dictionary updating. This is designed for easy inclusion of astropy's physical-type x-refs.
- Add ``numpydoc_xref_astropy_aliases``, an xref ChainMap of the above mappings that can be added to the ``numpydoc_xref_aliases`` in packages by dictionary updating. This is designed for easy inclusion of ALL of astropy's intersphinx offerings.

Fixes #39
Fixes #20
Request Review : @bsipocz @pllim @saimn @astrofrog 