### PR TITLE
add sphinx-changelog to sphinx-astropy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     sphinx-gallery
     pillow
     pytest-doctestplus>=0.10.1
+    sphinx-changelog>=1.1.2
 
 [options.extras_require]
 all = astropy


### PR DESCRIPTION
I'm not sure we actually want to do this, but it's inspired by my confusion in astropy/astropy#12083 where I thought the sphinx-changelog minversion should be set here instead of `astropy` itself. Making this change would have made astropy/astropy#12083 more of a hassle, but would make it more consistent to look here for all sphinx deps.

Note if we do this we'd want to update `astropy` to no longer explicitly depend on sphinx-changelog.