### PR TITLE
Update minimum required pytest-doctestplus version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes in sphinx-astropy
 1.6 (unreleased)
 ----------------
 
+- Updated minimum required version of ``pytest-doctestplus`` to 0.11. [#47]
 
 1.5 (2021-07-20)
 ----------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     sphinx-automodapi
     sphinx-gallery
     pillow
-    pytest-doctestplus>=0.10.1
+    pytest-doctestplus>=0.11
 
 [options.extras_require]
 all = astropy


### PR DESCRIPTION
The `astropy` documentation is about to start using the `testcleanup`
directive introduced in `pytest-doctestplus` 0.11.0.