### PR TITLE
DOC: Update matplotlib intersphinx URL

### DIFF
--- a/sphinx_astropy/conf/v1.py
+++ b/sphinx_astropy/conf/v1.py
@@ -61,7 +61,7 @@ intersphinx_mapping = {
               (None, 'http://data.astropy.org/intersphinx/numpy.inv')),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/',
               (None, 'http://data.astropy.org/intersphinx/scipy.inv')),
-    'matplotlib': ('https://matplotlib.org/',
+    'matplotlib': ('https://matplotlib.org/stable/',
                    (None, 'http://data.astropy.org/intersphinx/matplotlib.inv')),
     'astropy': ('https://docs.astropy.org/en/stable/', None),
     'h5py': ('https://docs.h5py.org/en/stable/', None)}


### PR DESCRIPTION
Goes with astropy/astropy#12705 to address astropy/astropy#12698 . Also see astropy/regions#392 .

@dhomeier , I cannot add you as "reviewer" but please review. Thanks!