### PR TITLE
CI: use hash for releaser actions' version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450  # v1.8.14
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Publishing should always use hash see SPEC8 for more of the reasoning.

(left the version to one before the latest release to double check if dependabot is picking up these actions, too)