### PR TITLE
Update release infrastructure

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,20 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - dependabot[bot]
       - pre-commit-ci
+      - dependabot
       - pre-commit-ci[bot]
+      - dependabot[bot]
+  categories:
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Documentation
+      labels:
+        - Documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,52 +2,39 @@ name: Release
 
 on:
   pull_request:
-    # We also want this workflow triggered if the 'Build all wheels' label is added
-    # or present when PR is updated
-    types:
-      - synchronize
-      - labeled
   push:
+    branches:
+      - master
     tags:
-      - '*'
+      - "v*"
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI
+  build:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@e97344095b099e1d729fe97429078c9975921d8a # v2
+    with:
+      save_artifacts: true
+      upload_to_pypi: false
+      test_extras: tests
+      test_command: pytest --pyargs sphinx_astropy
+
+  upload:
+    if: startsWith(github.ref, 'refs/tags/v')
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || contains(github.event.pull_request.labels.*.name, 'Build wheels'))
-
+    needs: [build]
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-      with:
-        python-version: "3.12"
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+          pattern: dist-*
+          path: dist
 
-    - name: Install build dependencies
-      run: python -m pip install pip build "twine>=3.3" -U
-
-    - name: Build package
-      run: python -m build --sdist --wheel .
-
-    - name: List result
-      run: ls -l dist
-
-    - name: Check long_description
-      run: python -m twine check --strict dist/*
-
-    - name: Test package
-      run: |
-        cd ..
-        python -m venv testenv
-        testenv/bin/pip install pip -U
-        testenv/bin/pip install pytest sphinx-astropy/dist/*.whl
-        testenv/bin/pytest sphinx-astropy/sphinx_astropy
-
-    - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -1,5 +1,5 @@
 # This workflow takes the GitHub release notes and updates the changelog on the
-# master branch with the body of the release notes, thereby keeping a log in
+# main branch with the body of the release notes, thereby keeping a log in
 # the git repo of the changes.
 
 name: "Update Changelog"
@@ -32,6 +32,6 @@ jobs:
       - name: Commit updated CHANGELOG
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
-          branch: master
+          branch: main
           commit_message: Update CHANGELOG
           file_pattern: CHANGES.md

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -1,0 +1,37 @@
+# This workflow takes the GitHub release notes and updates the changelog on the
+# master branch with the body of the release notes, thereby keeping a log in
+# the git repo of the changes.
+
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          persist-credentials: false
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
+        with:
+          release-notes: ${{ github.event.release.body }}
+          latest-version: ${{ github.event.release.name }}
+          path-to-changelog: CHANGES.md
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+        with:
+          branch: master
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGES.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,62 +1,47 @@
-Changes in sphinx-astropy
-=========================
+# Changelog
 
-2.0 (unreleased)
-----------------
-
-- No changes yet.
-
-
-1.10 (2025-08-06)
------------------
+## 1.10 (2025-08-06)
 
 - Update minimum required version of Sphinx to 4.0.0
   and Python to 3.9. [#78]
 
-1.9.1 (2023-06-07)
-------------------
+## 1.9.1 (2023-06-07)
 
-- Renamed ``[v2]`` optional dependencies key to ``[confv2]``
+- Renamed `[v2]` optional dependencies key to `[confv2]`
   to avoid triggering build error in Python 3.10 or earlier. [#63]
 
-1.9 (2023-06-06)
-----------------
+## 1.9 (2023-06-06)
 
-- To switch to ``pydata-sphinx-theme``, use ``sphinx_astropy.conf.v2``
-  and install the ``[v2]`` optional dependencies. [#59]
+- To switch to `pydata-sphinx-theme`, use `sphinx_astropy.conf.v2`
+  and install the `[v2]` optional dependencies. [#59]
 
 - Update minimum required version of Sphinx to 3.0.0. [#57]
 
-- ``check_sphinx_version`` is deprecated. [#57]
+- `check_sphinx_version` is deprecated. [#57]
 
-1.8 (2023-01-06)
-----------------
+## 1.8 (2023-01-06)
 
 - Update scipy intersphinx URL. [#53]
 
 - Ensure that jQuery is always installed with Sphinx 6+. [#56]
 
-1.7 (2022-01-10)
-----------------
+## 1.7 (2022-01-10)
 
-- Removed dependency on ``distutils``. As a result, ``packaging`` is now
+- Removed dependency on `distutils`. As a result, `packaging` is now
   a dependency. [#51]
 
-- Updated ``matplotlib`` URL for intersphinx. [#52]
+- Updated `matplotlib` URL for intersphinx. [#52]
 
-1.6 (2021-09-22)
-----------------
+## 1.6 (2021-09-22)
 
-- Updated minimum required version of ``pytest-doctestplus`` to 0.11. [#47]
+- Updated minimum required version of `pytest-doctestplus` to 0.11. [#47]
 
-1.5 (2021-07-20)
-----------------
+## 1.5 (2021-07-20)
 
-- ``doctest`` sphinx extension has been moved to ``pytest-doctestplus`` and
-  therefore ``pytest-doctestplus`` is now a required dependency. [#45]
+- `doctest` sphinx extension has been moved to `pytest-doctestplus` and
+  therefore `pytest-doctestplus` is now a required dependency. [#45]
 
-1.4 (2021-06-22)
-----------------
+## 1.4 (2021-06-22)
 
 - Updated intersphinx links. [#32, #36]
 
@@ -66,13 +51,11 @@ Changes in sphinx-astropy
 
 - Dropped support for Python 3.6. [#42]
 
-1.3 (2020-04-28)
-----------------
+## 1.3 (2020-04-28)
 
 - Add extension to include generated config in the docs. [#30]
 
-1.2 (2019-11-12)
-----------------
+## 1.2 (2019-11-12)
 
 - Updated minimum required version of Sphinx to 1.7 as Numpydoc dropped
   support for Sphinx older than 1.6 and the inherit docstring feature is
@@ -80,19 +63,16 @@ Changes in sphinx-astropy
 
 - Make sure all extensions are marked as parallel-safe. [#26]
 
-1.1.1 (2019-02-21)
-------------------
+## 1.1.1 (2019-02-21)
 
 - Fix app.info() deprecation warning for Sphinx >= 1.6. [#17]
 
-1.1 (2018-11-15)
-----------------
+## 1.1 (2018-11-15)
 
 - Added a new extension for controlling whether intersphinx is used on the command-line.
 
 - Added a new extension to give a clear warning if the _static folder is missing.
 
-1.0 (2018-02-07)
-----------------
+## 1.0 (2018-02-07)
 
 - Initial standalone version of this package (formerly packaged as part of astropy-helpers)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.rst
-include CHANGES.rst
+include CHANGES.md
 
 include setup.cfg
 include pyproject.toml


### PR DESCRIPTION
This is to enable easy single-click releases through the GitHub UI and auto-population on the changelog from the github release notes. I'll also enable trusted publishing on PyPI.