### PR TITLE
BLD/DEP: drop unused build-time dependency on wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = ["setuptools>=30.3.0",
             "setuptools_scm>=8.0.0",
-            "wheel"]
+]
 build-backend = 'setuptools.build_meta'
 
 [tool.setuptools_scm]


### PR DESCRIPTION
including wheel as a build time dependency was never necessary, but is a very common mistakes that was originally made in setuptools' own documentation, and presumably spread widely from there.