### PR TITLE
Exclude the physical-type aliases from the default numpydoc xref aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   are quoted strings such as `'power'`, which numpydoc treats as literal option
   values inside `{...}` parameter types, so they spuriously linked options that
   share a physical type's name. They remain available as an explicit opt-in via
-  `numpydoc_xref_aliases_astropy_physical_type`. [#NN]
+  `numpydoc_xref_aliases_astropy_physical_type`. [#103]
 
 ## 1.10 (2025-08-06)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Physical-type aliases are no longer cross-referenced by default. Their keys
+  are quoted strings such as `'power'`, which numpydoc treats as literal option
+  values inside `{...}` parameter types, so they spuriously linked options that
+  share a physical type's name. They remain available as an explicit opt-in via
+  `numpydoc_xref_aliases_astropy_physical_type`. [#NN]
+
 ## 1.10 (2025-08-06)
 
 - Update minimum required version of Sphinx to 4.0.0

--- a/sphinx_astropy/conf/v2.py
+++ b/sphinx_astropy/conf/v2.py
@@ -132,7 +132,13 @@ if ASTROPY_INSTALLED and minversion(astropy, "4.3"):
         "time-like": ":term:`astropy:time-like`",
     }
 
-# Aliases to Astropy's physical types. In packages these can be turned on with
+# Aliases to Astropy's physical types. These are NOT included in
+# ``numpydoc_xref_astropy_aliases`` below by default: their keys are quoted
+# strings such as 'power', and numpydoc treats a quoted string inside a
+# ``{...}`` parameter type as a literal option value. Enabling them therefore
+# cross-references any option that merely shares a physical type's name (e.g.
+# the 'power' option of a 'stretch' parameter) to that physical type. Packages
+# that really want physical-type x-refs can still opt in explicitly with
 # ``numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_physical_type)``
 # (if astropy is in the intersphinx mapping).
 numpydoc_xref_aliases_astropy_physical_type = {}  # works even if no astropy
@@ -140,7 +146,7 @@ if ASTROPY_INSTALLED and minversion(astropy, "4.3"):
 
     from astropy.units.physical import _name_physical_mapping
     for ptype in _name_physical_mapping.keys():
-        val = f":ref:`:ref: '{ptype}' <astropy:{ptype}>`"   # <= intersphinxed
+        val = f":ref:`'{ptype}' <astropy:{ptype}>`"   # <= intersphinxed
         numpydoc_xref_aliases_astropy_physical_type[f"'{ptype}'"] = val
 
     del ptype, val, _name_physical_mapping  # cleanup namespace
@@ -152,7 +158,6 @@ if ASTROPY_INSTALLED and minversion(astropy, "4.3"):
 # (if astropy is in the intersphinx mapping).
 numpydoc_xref_astropy_aliases = ChainMap(  # important at the top
     numpydoc_xref_aliases_astropy_glossary,
-    numpydoc_xref_aliases_astropy_physical_type
 )
 
 # -- Project information ------------------------------------------------------


### PR DESCRIPTION
This is to fix astropy issue [#19868](https://github.com/astropy/astropy/issues/19868): in the
rendered `simple_norm` docs, the `'power'` option of `stretch : {'linear', 'sqrt', 'power', ...}` is turned into a hyperlink to the **power** physical type. It's a meaningless link — `'power'` there is a literal option value, not a unit physical type.

This happens because `sphinx_astropy/conf/v2.py` builds `numpydoc_xref_aliases_astropy_physical_type` with keys that are *quoted* strings (`'power'`, `'energy'`, `'time'`, ...) and folds them into the default `numpydoc_xref_astropy_aliases`.

Numpydoc gives a quoted string a single meaning regardless of context, but the
common context is an enum of literal options:

```
stretch : {'linear', 'sqrt', 'power', ...}
```

Here `'power'` is a literal choice, not a type — but it's the same token the alias is keyed on, so alias substitution rewrites it into a cross-reference. About a dozen physical-type names collide with ordinary option words (`area`,
`energy`, `force`, `length`, `mass`, `power`, `pressure`, `speed`, `time`, `volume`, ...), so any `{...}` enum using one of those words gets a spurious link.

These aliases were added as an opt-in in https://github.com/astropy/sphinx-astropy/pull/40. The intended use was a parameter whose *type* is a physical quantity, written as a quoted name — e.g. `length : 'length'` linking to astropy's physical-types docs. The original comment documents them as something packages turn on explicitly with ``numpydoc_xref_aliases.update(numpydoc_xref_astropy_aliases)`` — but glossary and physical-type aliases were fused into a single ChainMap, so a package couldn't take the safe glossary aliases without also pulling in the colliding physical-type ones.

They also appear never to have actually worked properly anyway: the alias *value* has a double `:ref:` (`:ref:`:ref: '{ptype}' <...>``) since the very first commit (this is also fixed here)

The fix is to drop `numpydoc_xref_aliases_astropy_physical_type` from the default `numpydoc_xref_astropy_aliases` ChainMap. It stays defined and documented as an explicit opt-in for packages that genuinely want physical-type cross-refs (having it opt-in was the original intent):

```python
numpydoc_xref_aliases.update(numpydoc_xref_aliases_astropy_physical_type)
```

The glossary aliases remain on by default — they're all hyphenated `-like` terms (`time-like`, etc.) that don't collide with literal option values, so they're safe(r).

This also fixes the double `:ref:`, so the opt-in path now renders a correct link instead of literal `:ref: 'power'` text.

In future we could consider not automagically changing 'power' to a ref but having some kind of namespace like ``physical_type:power`` in docstrings to avoid any ambiguities.